### PR TITLE
Bug: Handle binary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,5 +33,6 @@ commit - 305dd5d5c2d7138f10052ba2cbff8e3bb9b1bc76
 #### Fixes
 
 - support for git diff.mnemonicPrefix in path parsing - 99759f8ae4d2304214637de41b331043eb469b91
+- error handling for binary files - 
 
 ## History

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,6 @@ commit - 305dd5d5c2d7138f10052ba2cbff8e3bb9b1bc76
 #### Fixes
 
 - support for git diff.mnemonicPrefix in path parsing - 99759f8ae4d2304214637de41b331043eb469b91
-- error handling for binary files - 
+- error handling for binary files - https://github.com/kokusenz/delta.lua/pull/3
 
 ## History

--- a/lua/delta/diff.lua
+++ b/lua/delta/diff.lua
@@ -88,8 +88,6 @@ M.get_diff_data = function(diff, language)
     --- @type DiffData
     local file_data = {
         hunks = {},
-        old_path = nil,
-        new_path = nil,
         language = language
     }
 
@@ -99,6 +97,9 @@ M.get_diff_data = function(diff, language)
     local diff_line_num = 0 -- Track line number in diff output
 
     for _, line in ipairs(lines) do
+        if line:match('^Binary files ') then
+            return file_data
+        end
         if line:match('^@@') then
             -- hunk header: @@ -old_start,old_count +new_start,new_count @@ [context]
             local old_info, new_info, context = line:match('^@@[%s]+%-([^%s]+)[%s]+%+([^%s]+)[%s]+@@(.*)$')
@@ -196,14 +197,24 @@ M.get_diff_data_git = function(diff)
     local current_file_lines = {}
     local current_old_path = nil
     local current_new_path = nil
+    local current_is_new_file = nil
+    local current_old_file_mode = nil
+    local current_new_file_mode = nil
+    local current_old_blob_hash = nil
+    local current_new_blob_hash = nil
 
     local function finalize_current_file(file_lines)
-        if #file_lines > 0 and current_new_path then
+        if #file_lines > 0 then
             local file_diff_string = table.concat(file_lines, '\n')
-            local language = utils.get_language_from_filename(current_new_path)
+            local language = current_new_path and utils.get_language_from_filename(current_new_path) or nil
             local file_data = M.get_diff_data(file_diff_string, language)
             file_data.old_path = current_old_path
             file_data.new_path = current_new_path
+            file_data.new_file = current_is_new_file
+            file_data.old_file_mode = current_old_file_mode
+            file_data.new_file_mode = current_new_file_mode
+            file_data.old_blob_hash = current_old_blob_hash
+            file_data.new_blob_hash = current_new_blob_hash
             table.insert(result, file_data)
         end
     end
@@ -214,15 +225,37 @@ M.get_diff_data_git = function(diff)
             -- new file starting: calculate the diff for the old file
             finalize_current_file(current_file_lines)
             current_file_lines = {}
+            -- now try to parse all the metadata we can find for the new file
             local j = i
-            while j <= #lines and not lines[j]:match('^%-%-%-') and not lines[j + 1]:match('^%+%+%+') do
+            while j <= #lines and not (lines[j]:match('^@@') or lines[j]:match('^Binary files ')) do
+                local new_file_mode_hash = lines[j]:match('^new file mode (%d+)')
+                if new_file_mode_hash then
+                    current_is_new_file = true
+                    current_new_file_mode = new_file_mode_hash
+                end
+
+                local old_blob_hash, new_blob_hash, file_mode_hash = lines[j]:match('^index (%w+)..(%w+) (%d*)')
+                current_old_blob_hash = old_blob_hash or current_old_blob_hash
+                current_new_blob_hash = new_blob_hash or current_new_blob_hash
+
+                local old_file_hash = lines[j]:match('^old mode (%d+)')
+                local new_file_hash = lines[j]:match('^new mode (%d+)')
+                -- if match for "new mode" then use that, or if match in index use that, or potentially keep using the match found in "new file mode" 
+                current_new_file_mode = new_file_hash or file_mode_hash or current_new_file_mode
+                -- if match for "old mode" then use that, or if match in index use that
+                current_old_file_mode = old_file_hash or file_mode_hash or current_old_file_mode
+
+                local old_path = lines[j]:match('^%-%-%-[%s]+%w/(.+)$')
+                    or lines[j]:match('^%-%-%-([%s])+/dev/null$')
+                    or lines[j]:match('diff %-%-git[%s]+%w/(.+)[%s]+%w/.+$')
+                local new_path = lines[j]:match('^%+%+%+[%s]+%w/(.+)$')
+                    or lines[j]:match('^%+%+%+([%s])+/dev/null$')
+                    or lines[j]:match('diff %-%-git[%s]+%w/.+[%s]+%w/(.+)$')
+                current_old_path = old_path or current_old_path
+                current_new_path = new_path or current_new_path
                 j = j + 1
             end
-            current_old_path = lines[j]:match('^%-%-%-[%s]+%w/(.+)$') or lines[j]:match(
-                '^%-%-%-([%s])+/dev/null$')
-            current_new_path = lines[j + 1]:match('^%+%+%+[%s]+%w/(.+)$') or lines[j + 1]:match(
-                '^%+%+%+([%s])+/dev/null$')
-            i = j + 2
+            i = j
         else
             -- normal lines of code
             table.insert(current_file_lines, lines[i])
@@ -263,6 +296,9 @@ M.create_formatted_buffer = function(diff_data_set)
             local path_title = file_data.new_path
             if file_data.new_path and file_data.old_path and file_data.new_path ~= file_data.old_path then
                 path_title = file_data.old_path .. " ⟶   " .. file_data.new_path
+            end
+            if file_data.new_file then
+                path_title = 'added: ' .. path_title
             end
             table.insert(output_lines, path_title)
             table.insert(delta_artifacts, { row_number = current_line_num, content = path_title, type = "title" })
@@ -557,6 +593,11 @@ return M
 --- @field old_path string | nil Path to old file (from --- a/...)
 --- @field new_path string | nil Path to new file (from +++ b/...)
 --- @field language string | nil language of file
+--- @field new_file boolean | nil captures the "new file mode"; true if new file
+--- @field old_file_mode number | nil for example, 100644 is a regular file with read/write permissions
+--- @field new_file_mode number | nil for example, 100644 is a regular file with read/write permissions
+--- @field old_blob_hash string | nil  old
+--- @field new_blob_hash string | nil  old
 
 -- originally the types were meant to allow different artifacts to have different highlights.
 -- if I want this to be useful, I would need to update my code to identify artifacts by both row and column.

--- a/lua/delta/diff.lua
+++ b/lua/delta/diff.lua
@@ -225,6 +225,13 @@ M.get_diff_data_git = function(diff)
             -- new file starting: calculate the diff for the old file
             finalize_current_file(current_file_lines)
             current_file_lines = {}
+            current_old_path = nil
+            current_new_path = nil
+            current_is_new_file = nil
+            current_old_file_mode = nil
+            current_new_file_mode = nil
+            current_old_blob_hash = nil
+            current_new_blob_hash = nil
             -- now try to parse all the metadata we can find for the new file
             local j = i
             while j <= #lines and not (lines[j]:match('^@@') or lines[j]:match('^Binary files ')) do
@@ -246,10 +253,8 @@ M.get_diff_data_git = function(diff)
                 current_old_file_mode = old_file_hash or file_mode_hash or current_old_file_mode
 
                 local old_path = lines[j]:match('^%-%-%-[%s]+%w/(.+)$')
-                    or lines[j]:match('^%-%-%-([%s])+/dev/null$')
                     or lines[j]:match('diff %-%-git[%s]+%w/(.+)[%s]+%w/.+$')
                 local new_path = lines[j]:match('^%+%+%+[%s]+%w/(.+)$')
-                    or lines[j]:match('^%+%+%+([%s])+/dev/null$')
                     or lines[j]:match('diff %-%-git[%s]+%w/.+[%s]+%w/(.+)$')
                 current_old_path = old_path or current_old_path
                 current_new_path = new_path or current_new_path

--- a/lua/delta/utils.lua
+++ b/lua/delta/utils.lua
@@ -166,6 +166,8 @@ end
 --- @return string[] cmd
 M.build_git_diff_cmd_with_flags = function(effective, ref, path)
     local flags = {'git', 'diff'}
+    -- always
+    table.insert(flags, '--full-index')
     if effective.context ~= nil then
         table.insert(flags, string.format('-U%d', effective.context))
     end

--- a/tests/delta/test_integrations.lua
+++ b/tests/delta/test_integrations.lua
@@ -102,6 +102,47 @@ local git_diff_fixture = table.concat({
     " local w = 4",
 }, "\n")
 
+-- A temp git repo with a committed binary file and a working-tree modification to it.
+-- The binary content contains a null byte so git classifies it as binary.
+local setup_tmpdir_binary_file_repo = [[
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, 'p')
+    vim.fn.system('git -C ' .. tmpdir .. ' init')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.email "test@test.com"')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.name "Test"')
+    -- Write initial binary content: a null byte makes git classify the file as binary
+    vim.fn.system("printf '\\x00\\x01\\x02\\x03' > " .. tmpdir .. "/photo.bin")
+    vim.fn.system('git -C ' .. tmpdir .. ' add photo.bin')
+    vim.fn.system('git -C ' .. tmpdir .. ' commit -m "initial"')
+    -- Modify the binary file so git sees a change
+    vim.fn.system("printf '\\x00\\x01\\x02\\x04' > " .. tmpdir .. "/photo.bin")
+    vim.cmd('cd ' .. tmpdir)
+    vim.cmd('edit ' .. tmpdir .. '/photo.bin')
+    _G.fixture = { tmpdir = tmpdir }
+]]
+
+-- A temp git repo with a new (untracked) .lua file, used to exercise new_file = true.
+local setup_tmpdir_new_file_repo = [[
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, 'p')
+    vim.fn.system('git -C ' .. tmpdir .. ' init')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.email "test@test.com"')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.name "Test"')
+    -- Commit one existing file so the repo has a valid HEAD
+    local f = io.open(tmpdir .. '/existing.lua', 'w')
+    f:write('local x = 1\n')
+    f:close()
+    vim.fn.system('git -C ' .. tmpdir .. ' add existing.lua')
+    vim.fn.system('git -C ' .. tmpdir .. ' commit -m "initial"')
+    -- Write a new file that git has never seen (untracked)
+    local f2 = io.open(tmpdir .. '/newfile.lua', 'w')
+    f2:write('local a = 1\nlocal b = 2\n')
+    f2:close()
+    vim.cmd('cd ' .. tmpdir)
+    vim.cmd('edit ' .. tmpdir .. '/newfile.lua')
+    _G.fixture = { tmpdir = tmpdir, newfile_path = tmpdir .. '/newfile.lua' }
+]]
+
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- top-level set
 
@@ -307,6 +348,60 @@ T['patch_diff integration']['failure path: empty diffstring returns nil and noti
     eq(result, vim.NIL)
     local notify_called = child.lua_get('_G.fixture.notify_called')
     eq(notify_called, true)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- git_diff binary file integration
+
+T['git_diff binary file integration'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua(setup_tmpdir_binary_file_repo)
+        end,
+    },
+})
+
+T['git_diff binary file integration']['happy path: returns valid buffer with one entry and no hunks'] = function()
+    local bufnr = child.lua_get('M.git_diff("HEAD", "photo.bin", {})')
+    eq(type(bufnr), 'number')
+    local is_valid = child.lua_get(string.format('vim.api.nvim_buf_is_valid(%d)', bufnr))
+    eq(is_valid, true)
+    local has_diff_data = child.lua_get(string.format('vim.b[%d].delta_diff_data_set ~= nil', bufnr))
+    eq(has_diff_data, true)
+    local entry_count = child.lua_get(string.format('#vim.b[%d].delta_diff_data_set', bufnr))
+    eq(entry_count, 1)
+    local hunk_count = child.lua_get(string.format('#vim.b[%d].delta_diff_data_set[1].hunks', bufnr))
+    eq(hunk_count, 0)
+    local new_path = child.lua_get(string.format('vim.b[%d].delta_diff_data_set[1].new_path', bufnr))
+    eq(new_path, 'photo.bin')
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- git_diff new file integration
+
+T['git_diff new file integration'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua(setup_tmpdir_new_file_repo)
+        end,
+    },
+})
+
+T['git_diff new file integration']['happy path: returns valid buffer with one entry flagged as new_file'] = function()
+    local bufnr = child.lua_get('M.git_diff("HEAD", _G.fixture.newfile_path, { new_file = true })')
+    eq(type(bufnr), 'number')
+    local is_valid = child.lua_get(string.format('vim.api.nvim_buf_is_valid(%d)', bufnr))
+    eq(is_valid, true)
+    local has_diff_data = child.lua_get(string.format('vim.b[%d].delta_diff_data_set ~= nil', bufnr))
+    eq(has_diff_data, true)
+    local entry_count = child.lua_get(string.format('#vim.b[%d].delta_diff_data_set', bufnr))
+    eq(entry_count, 1)
+    local is_new_file = child.lua_get(string.format('vim.b[%d].delta_diff_data_set[1].new_file', bufnr))
+    eq(is_new_file, true)
+    local new_path = child.lua_get(string.format('vim.b[%d].delta_diff_data_set[1].new_path', bufnr))
+    eq(new_path, 'newfile.lua')
+    local hunk_count = child.lua_get(string.format('#vim.b[%d].delta_diff_data_set[1].hunks', bufnr))
+    eq(hunk_count > 0, true)
 end
 
 return T

--- a/tests/delta/test_parsing.lua
+++ b/tests/delta/test_parsing.lua
@@ -158,6 +158,30 @@ local git_diff_artifacts_in_content_git_diff_deleted = table.concat({
     " local c = 3",
 }, "\n")
 
+-- binary file diff: no ---/+++ header
+local binary_file_git_diff = table.concat({
+    "diff --git a/photo.jpg b/photo.jpg",
+    "index abc1234..def5678 100644",
+    "Binary files a/photo.jpg and b/photo.jpg differ",
+}, "\n")
+
+-- mode-only change: no ---/+++ header
+local mode_only_git_diff = table.concat({
+    "diff --git a/script.sh b/script.sh",
+    "old mode 100644",
+    "new mode 100755",
+}, "\n")
+
+-- new file
+local new_file_mode_git_diff = table.concat({
+    "diff --git a/newfile.md b/newfile.md",
+    "new file mode 100644",
+    "index 0000000000000000000000000000000000000000..039727ec5a50d0ed45ff67e6f4c9b953bd23c17d",
+    "--- /dev/null",
+    "+++ b/newfile.md",
+    "@@ -0,0 +1 @@",
+    "+lol"
+}, "\n")
 local git_diff_artifacts_in_content_git_diff_added = table.concat({
     "diff --git a/foo.lua b/foo.lua",
     "index abc1234..def5678 100644",
@@ -350,6 +374,18 @@ GetDiffData.get_diff_data__property_cases = {
     {
         name = 'lines that start with a plus but arent added',
         diff = "@@ -5,3 +4,0 @@\n +line1\n-line2\n line3",
+    },
+    {
+        name = 'binary file diff (no hunks)',
+        diff = "Binary files a/photo.jpg and b/photo.jpg differ",
+    },
+    {
+        name = 'mode-only change (no content)',
+        diff = "",
+    },
+    {
+        name = 'new file with single added line',
+        diff = "@@ -0,0 +1 @@\n+new line",
     },
 }
 
@@ -557,6 +593,279 @@ T['get_diff_data_git()']['returns one entry per file with mnemonic prefix'] = fu
     eq(result.count, 2)
     eq(result.first, 'foo.lua')
     eq(result.second, 'bar.py')
+end
+
+T['get_diff_data_git()']['handles binary file diff (no hunks)'] = function()
+    child.lua([[_G.fixture.diff = ...]], { binary_file_git_diff })
+    local result = child.lua_get([[(function()
+        local data = M.get_diff_data_git(_G.fixture.diff)
+        return { count = #data, new_path = data[1].new_path, hunk_count = #data[1].hunks }
+    end)()]])
+    eq(result.count, 1)
+    eq(result.new_path, 'photo.jpg')
+    eq(result.hunk_count, 0)
+end
+
+T['get_diff_data_git()']['handles mode-only change (no content lines to parse)'] = function()
+    child.lua([[_G.fixture.diff = ...]], { mode_only_git_diff })
+    local result = child.lua_get([[(function()
+        local data = M.get_diff_data_git(_G.fixture.diff)
+        -- mode-only changes have no content lines, so they're not added to result
+        return { count = #data }
+    end)()]])
+    eq(result.count, 0)
+end
+
+T['get_diff_data_git()']['handles new file with mode and hunks'] = function()
+    child.lua([[_G.fixture.diff = ...]], { new_file_mode_git_diff })
+    local result = child.lua_get([[(function()
+        local data = M.get_diff_data_git(_G.fixture.diff)
+        return {
+            count = #data,
+            new_path = data[1] and data[1].new_path or nil,
+            is_new = data[1] and data[1].new_file or nil,
+            hunk_count = data[1] and #data[1].hunks or nil,
+            new_mode = data[1] and data[1].new_file_mode or nil,
+            line_count = data[1] and data[1].hunks[1] and #data[1].hunks[1].lines or 0
+        }
+    end)()]])
+    eq(result.count, 1)
+    eq(result.new_path, 'newfile.md')
+    eq(result.is_new, true)
+    eq(result.hunk_count, 1)
+    eq(result.new_mode, '100644')
+    eq(result.line_count, 1)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- get_diff_data_git() - property based tests
+
+local GetDiffDataGit = {}
+
+-- Curated property test cases that cover different diff scenarios
+GetDiffDataGit.get_diff_data_git__property_cases = {
+    {
+        name = 'single file with regular changes',
+        diff = table.concat({
+            "diff --git a/test.lua b/test.lua",
+            "index abc1234..def5678 100644",
+            "--- a/test.lua",
+            "+++ b/test.lua",
+            "@@ -1,2 +1,2 @@",
+            "-old line",
+            "+new line",
+            " context",
+        }, "\n"),
+    },
+    {
+        name = 'multi-file diff',
+        diff = table.concat({
+            "diff --git a/file1.lua b/file1.lua",
+            "index abc1234..def5678 100644",
+            "--- a/file1.lua",
+            "+++ b/file1.lua",
+            "@@ -1,1 +1,1 @@",
+            "-old",
+            "+new",
+            "diff --git a/file2.py b/file2.py",
+            "index def5678..abc9012 100644",
+            "--- a/file2.py",
+            "+++ b/file2.py",
+            "@@ -5,1 +5,1 @@",
+            "-python",
+            "+Python",
+        }, "\n"),
+    },
+    {
+        name = 'binary file',
+        diff = table.concat({
+            "diff --git a/image.png b/image.png",
+            "index abc1234..def5678 100644",
+            "Binary files a/image.png and b/image.png differ",
+        }, "\n"),
+    },
+    {
+        name = 'new file',
+        diff = table.concat({
+            "diff --git a/newfile.txt b/newfile.txt",
+            "new file mode 100644",
+            "index 0000000..abc1234 100644",
+            "--- /dev/null",
+            "+++ b/newfile.txt",
+            "@@ -0,0 +1,1 @@",
+            "+new content",
+        }, "\n"),
+    },
+    {
+        name = 'multiple hunks in single file',
+        diff = table.concat({
+            "diff --git a/code.lua b/code.lua",
+            "index abc1234..def5678 100644",
+            "--- a/code.lua",
+            "+++ b/code.lua",
+            "@@ -1,2 +1,2 @@",
+            "-old1",
+            "+new1",
+            " context",
+            "@@ -10,2 +10,2 @@",
+            "-old2",
+            "+new2",
+            " context2",
+        }, "\n"),
+    },
+}
+
+GetDiffDataGit.properties = {}
+
+-- Property: every entry in result has old_path and new_path set correctly
+-- Returns true on success, or an error string on the first violation
+GetDiffDataGit.properties.paths_are_parsed = [[(function()
+    local diff = _G.fixture.diff
+    local result = M.get_diff_data_git(diff)
+    
+    for idx, entry in ipairs(result) do
+        -- For binary files and mode-only changes, paths should still be extracted from the diff header
+        if not entry.new_path then
+            return 'entry ' .. idx .. ': new_path is nil'
+        end
+        -- old_path may be nil for new files, but should exist otherwise
+        if entry.new_path and not entry.old_path and not entry.new_file then
+            -- Only new files can have nil old_path
+            return 'entry ' .. idx .. ': old_path is nil but not a new file'
+        end
+    end
+    return true
+end)()]]
+
+-- Property: every file has correct metadata (new_file, old_file_mode, new_file_mode, blob hashes)
+-- Returns true on success
+GetDiffDataGit.properties.metadata_is_captured = [[(function()
+    local diff = _G.fixture.diff
+    local result = M.get_diff_data_git(diff)
+    
+    for idx, entry in ipairs(result) do
+        -- For new files, new_file should be true
+        if entry.new_file == true then
+            -- New files should have some hash information if they have hunks
+            if #entry.hunks > 0 and not entry.new_blob_hash then
+                return 'new file entry ' .. idx .. ' with hunks: new_blob_hash not captured'
+            end
+        end
+        
+        -- For regular files, both old and new blob hashes should be captured if there are hunks
+        if not entry.new_file and #entry.hunks > 0 then
+            if not entry.old_blob_hash then
+                return 'entry ' .. idx .. ' with hunks: old_blob_hash not captured'
+            end
+            if not entry.new_blob_hash then
+                return 'entry ' .. idx .. ' with hunks: new_blob_hash not captured'
+            end
+        end
+        
+        -- Blob hashes should match expected pattern (hex characters) if present
+        if entry.old_blob_hash and not entry.old_blob_hash:match('^%x+$') then
+            return 'entry ' .. idx .. ': old_blob_hash is not hex: ' .. entry.old_blob_hash
+        end
+        if entry.new_blob_hash and not entry.new_blob_hash:match('^%x+$') then
+            return 'entry ' .. idx .. ': new_blob_hash is not hex: ' .. entry.new_blob_hash
+        end
+    end
+    return true
+end)()]]
+
+-- Property: result array size matches number of files in the diff
+-- Returns true on success
+GetDiffDataGit.properties.correct_file_count = [[(function()
+    local diff = _G.fixture.diff
+    local lines = vim.split(diff, '\n', { plain = true })
+    
+    -- Count unique "diff --git" markers (one per file)
+    local expected_count = 0
+    for _, line in ipairs(lines) do
+        if line:match('^diff %-%-git') then
+            expected_count = expected_count + 1
+        end
+    end
+    
+    local result = M.get_diff_data_git(diff)
+    if #result ~= expected_count then
+        return 'expected ' .. expected_count .. ' files but got ' .. #result
+    end
+    return true
+end)()]]
+
+-- Property: hunks are empty for binary files and mode-only changes; non-empty for regular diffs
+-- Returns true on success
+GetDiffDataGit.properties.hunks_match_diff_type = [[(function()
+    local diff = _G.fixture.diff
+    local lines = vim.split(diff, '\n', { plain = true })
+    local result = M.get_diff_data_git(diff)
+    
+    for idx, entry in ipairs(result) do
+        local is_binary = false
+        local has_hunk_headers = false
+        
+        -- Check if this file is binary
+        for _, line in ipairs(lines) do
+            if line:match('^Binary files') then
+                is_binary = true
+                break
+            end
+            if line:match('^@@') then
+                has_hunk_headers = true
+                break
+            end
+        end
+        
+        -- Binary files should have no hunks
+        if is_binary and #entry.hunks > 0 then
+            return 'binary file entry ' .. idx .. ' should have no hunks'
+        end
+        
+        -- Files with hunk headers should have hunks
+        if has_hunk_headers and #entry.hunks == 0 then
+            return 'entry ' .. idx .. ' with hunk headers should have hunks'
+        end
+    end
+    return true
+end)()]]
+
+-- Property: language is correctly inferred from file extension
+-- Returns true on success
+GetDiffDataGit.properties.language_inference = [[(function()
+    local diff = _G.fixture.diff
+    local result = M.get_diff_data_git(diff)
+    
+    for idx, entry in ipairs(result) do
+        if not entry.new_path then goto continue end
+        
+        -- Check that language matches the extension (if we know about it)
+        local ext = entry.new_path:match('%.([^%.]+)$')
+        if ext then
+            local expected_language = nil
+            if ext == 'lua' then expected_language = 'lua'
+            elseif ext == 'py' then expected_language = 'python'
+            end
+            
+            if expected_language and entry.language ~= expected_language then
+                return 'entry ' .. idx .. ' with extension .' .. ext .. ' has language=' .. tostring(entry.language) .. ' (expected ' .. expected_language .. ')'
+            end
+        end
+        
+        ::continue::
+    end
+    return true
+end)()]]
+
+T['get_diff_data_git() properties'] = new_set()
+for prop_name, prop in pairs(GetDiffDataGit.properties) do
+    for _, case in ipairs(GetDiffDataGit.get_diff_data_git__property_cases) do
+        T['get_diff_data_git() properties'][prop_name .. ': ' .. case.name] = function()
+            child.lua([[_G.fixture.diff = ...]], { case.diff })
+            local result = child.lua_get(prop)
+            eq(result, true)
+        end
+    end
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────

--- a/tests/delta/test_parsing.lua
+++ b/tests/delta/test_parsing.lua
@@ -182,6 +182,26 @@ local new_file_mode_git_diff = table.concat({
     "@@ -0,0 +1 @@",
     "+lol"
 }, "\n")
+
+-- two-file diff: first is a new file, second is a regular change
+-- used to verify that new_file / blob hash metadata does not bleed from file 1 to file 2
+local new_file_then_regular_git_diff = table.concat({
+    "diff --git a/added.lua b/added.lua",
+    "new file mode 100644",
+    "index 0000000..aaa1111",
+    "--- /dev/null",
+    "+++ b/added.lua",
+    "@@ -0,0 +1 @@",
+    "+new content",
+    "diff --git a/existing.lua b/existing.lua",
+    "index bbb2222..ccc3333 100644",
+    "--- a/existing.lua",
+    "+++ b/existing.lua",
+    "@@ -1,1 +1,1 @@",
+    "-old",
+    "+new",
+}, "\n")
+
 local git_diff_artifacts_in_content_git_diff_added = table.concat({
     "diff --git a/foo.lua b/foo.lua",
     "index abc1234..def5678 100644",
@@ -635,6 +655,28 @@ T['get_diff_data_git()']['handles new file with mode and hunks'] = function()
     eq(result.hunk_count, 1)
     eq(result.new_mode, '100644')
     eq(result.line_count, 1)
+end
+
+T['get_diff_data_git()']['new_file metadata does not bleed into the following regular file'] = function()
+    child.lua([[_G.fixture.diff = ...]], { new_file_then_regular_git_diff })
+    local result = child.lua_get([[(function()
+        local data = M.get_diff_data_git(_G.fixture.diff)
+        local second = data[2]
+        return {
+            count = #data,
+            second_path = second and second.new_path or nil,
+            second_new_file = second and second.new_file or nil,
+            second_old_blob = second and second.old_blob_hash or nil,
+            second_new_blob = second and second.new_blob_hash or nil,
+        }
+    end)()]])
+    eq(result.count, 2)
+    eq(result.second_path, 'existing.lua')
+    -- new_file flag must not carry over from the first file
+    eq(result.second_new_file, nil)
+    -- blob hashes must come from the second file's index line, not the first file's
+    eq(result.second_old_blob, 'bbb2222')
+    eq(result.second_new_blob, 'ccc3333')
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
metadata parsing is updated to account for some found bugs, and capture more git metadata in different shapes. binary files are now displayed. "added" is now added to the git diff header, based on whether git tells me this is a new file, taking advantage of the new parsing