### PR TITLE
Bug: Agnostic Nvim Cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ commit - 305dd5d5c2d7138f10052ba2cbff8e3bb9b1bc76
 #### Fixes
 
 - support for git diff.mnemonicPrefix in path parsing - 99759f8ae4d2304214637de41b331043eb469b91
-- error handling for binary files - https://github.com/kokusenz/delta.lua/pull/3
+- error handling for binary files - 9d3a6884cb60bc6e653ba9868b82bb26648d5aae
+- make the git diff api independent of the neovim cwd, unless no path is given - https://github.com/kokusenz/delta.lua/pull/4
 
 ## History

--- a/lua/delta/diff.lua
+++ b/lua/delta/diff.lua
@@ -17,7 +17,7 @@ M.git_diff = function(ref, path, opts)
     end
     local diff_cmd = utils.build_git_diff_cmd_with_flags(effective, ref, git_root, path)
     local diff_result = vim.system(diff_cmd):wait()
-    assert(diff_result.code == 0 or diff_result.code == 1, 'An error occured while running git diff - ' .. diff_result.stderr)
+    assert(diff_result.code == 0 or diff_result.code == 1, 'An error occurred while running git diff - ' .. diff_result.stderr)
     local diffstring = vim.trim(diff_result.stdout)
 
     if diffstring == '' then

--- a/lua/delta/diff.lua
+++ b/lua/delta/diff.lua
@@ -11,20 +11,13 @@ local config = require('delta.config')
 --- @return number | nil bufnr
 M.git_diff = function(ref, path, opts)
     local effective = vim.tbl_deep_extend('force', config.options, opts or {})
-    local git_root = vim.fn.systemlist('git rev-parse --show-toplevel')[1]
-    if vim.v.shell_error ~= 0 then
-        vim.notify('Not in a git repository', vim.log.levels.ERROR)
-        return
-    end
+    local git_root = utils.get_git_root(path or vim.fn.getcwd())
     if effective.new_file and path and path:sub(1, 1) == '/' then
         path = path:sub(#git_root + 2)
     end
-    local diff_cmd = utils.build_git_diff_cmd_with_flags(effective, ref, path)
-    local diff_result = vim.system(diff_cmd, { cwd = git_root }):wait()
-    if diff_result.code ~= 0 and diff_result.code ~= 1 then
-        vim.notify('An error occured while running git diff - ' .. tostring(diff_result.stderr), vim.log.levels.ERROR)
-        return
-    end
+    local diff_cmd = utils.build_git_diff_cmd_with_flags(effective, ref, git_root, path)
+    local diff_result = vim.system(diff_cmd):wait()
+    assert(diff_result.code == 0 or diff_result.code == 1, 'An error occured while running git diff - ' .. diff_result.stderr)
     local diffstring = vim.trim(diff_result.stdout)
 
     if diffstring == '' then
@@ -34,6 +27,7 @@ M.git_diff = function(ref, path, opts)
 
     local data = M.get_diff_data_git(diffstring)
     local buf_id = M.create_formatted_buffer(data)
+    vim.b[buf_id].git_root = git_root
     return buf_id
 end
 
@@ -429,14 +423,7 @@ end
 --- @param bufnr number id of buffer with the diffed contents
 M.syntax_highlight_git_diff = function(bufnr)
     local diff_data_set = M.get_buf_diff_data_set(bufnr)
-    if (diff_data_set == nil) then return end
-    --- @cast diff_data_set DiffData[]
-
-    local git_root = vim.fn.systemlist('git rev-parse --show-toplevel')[1]
-    if vim.v.shell_error ~= 0 then
-        vim.notify("Not in a git repository", vim.log.levels.WARN)
-        return
-    end
+    local git_root = M.get_buf_git_root(bufnr)
 
     for _, diff_data in pairs(diff_data_set) do
         local source_path = git_root .. '/' .. diff_data.new_path
@@ -550,27 +537,26 @@ M.setup_delta_statuscolumn = function(bufnr, winid)
 end
 
 --- @param bufnr number
---- @return DiffData[] | nil
+--- @return DiffData[]
 M.get_buf_diff_data_set = function(bufnr)
     local delta_files_data = vim.b[bufnr].delta_diff_data_set
-
-    if delta_files_data == nil then
-        vim.notify("Buffer did not contain delta diff data", vim.log.levels.WARN)
-        return
-    end
+    assert(delta_files_data ~= nil, 'Buffer did not contain expected Delta.lua delta diff data')
     return delta_files_data
+end
+
+--- @param bufnr number
+--- @return string
+M.get_buf_git_root = function(bufnr)
+    local git_root = vim.b[bufnr].git_root
+    assert(git_root ~= nil, 'Buffer did not contain expected Delta.lua git root data')
+    return git_root
 end
 
 --- @param bufnr number
 --- @return DeltaArtifact[] | nil
 M.get_delta_artifact_data = function(bufnr)
     local delta_artifacts = vim.b[bufnr].delta_artifacts
-
-    if delta_artifacts == nil then
-        vim.notify("Buffer did not contain delta artifact data", vim.log.levels.WARN)
-        return
-    end
-
+    assert(delta_artifacts ~= nil, 'Buffer did not contain expected Delta.lua delta artifact data')
     return delta_artifacts
 end
 

--- a/lua/delta/utils.lua
+++ b/lua/delta/utils.lua
@@ -214,7 +214,7 @@ M.get_git_root = function(path)
     -- returns the directory containing the path
     local file_dir = vim.fn.isdirectory(path) == 1 and path or vim.fn.fnamemodify(path, ':h')
     local rev_parse_result = vim.system({ 'git', '-C', file_dir, 'rev-parse', '--show-toplevel' }):wait()
-    assert(rev_parse_result.code == 0, 'Not in a git repository. - ' .. rev_parse_result.stderr)
+    assert(rev_parse_result.code == 0, 'An error occurred while running git rev-parse - ' .. rev_parse_result.stderr)
     return vim.trim(rev_parse_result.stdout)
 end
 

--- a/lua/delta/utils.lua
+++ b/lua/delta/utils.lua
@@ -162,12 +162,14 @@ end
 --- To add a new git diff flag, insert a new entry here.
 --- @param effective DeltaOpts
 --- @param ref string
+--- @param git_root string
 --- @param path string | nil
 --- @return string[] cmd
-M.build_git_diff_cmd_with_flags = function(effective, ref, path)
-    local flags = {'git', 'diff'}
+M.build_git_diff_cmd_with_flags = function(effective, ref, git_root, path)
+    local flags = {'git', '-C', git_root, 'diff'}
     -- always
     table.insert(flags, '--full-index')
+
     if effective.context ~= nil then
         table.insert(flags, string.format('-U%d', effective.context))
     end
@@ -203,6 +205,17 @@ M.read_file_lines = function(filepath)
     file:close()
 
     return lines
+end
+
+--- gets the git root of the path; if there is no git root, then throws an error
+--- @param path string works on filepath or directory path
+--- @return string git_root
+M.get_git_root = function(path)
+    -- returns the directory containing the path
+    local file_dir = vim.fn.isdirectory(path) == 1 and path or vim.fn.fnamemodify(path, ':h')
+    local rev_parse_result = vim.system({ 'git', '-C', file_dir, 'rev-parse', '--show-toplevel' }):wait()
+    assert(rev_parse_result.code == 0 or rev_parse_result.code == 1, 'Not in a git repository. Cannot open git diff delta.lua buffer. - ' .. rev_parse_result.stderr)
+    return vim.trim(rev_parse_result.stdout)
 end
 
 return M

--- a/lua/delta/utils.lua
+++ b/lua/delta/utils.lua
@@ -214,7 +214,7 @@ M.get_git_root = function(path)
     -- returns the directory containing the path
     local file_dir = vim.fn.isdirectory(path) == 1 and path or vim.fn.fnamemodify(path, ':h')
     local rev_parse_result = vim.system({ 'git', '-C', file_dir, 'rev-parse', '--show-toplevel' }):wait()
-    assert(rev_parse_result.code == 0 or rev_parse_result.code == 1, 'Not in a git repository. Cannot open git diff delta.lua buffer. - ' .. rev_parse_result.stderr)
+    assert(rev_parse_result.code == 0, 'Not in a git repository. - ' .. rev_parse_result.stderr)
     return vim.trim(rev_parse_result.stdout)
 end
 

--- a/tests/delta/test_buf_creation.lua
+++ b/tests/delta/test_buf_creation.lua
@@ -74,16 +74,14 @@ local T = new_set({
                     },
                 }
                 package.loaded['delta.utils'] = {
-                    build_git_diff_cmd_with_flags = function(_effective, _ref, _path)
+                    build_git_diff_cmd_with_flags = function(_effective, _ref, _git_root, _path)
                         return { 'git', 'diff', 'HEAD' }
                     end,
+                    get_git_root = function(_path) return '/fake/git/root' end,
                     get_window_width = function(_winid) return 80 end,
                     apply_highlights  = function(_bufnr, _highlights) end,
-                    get_language_from_filename = function(filename)
-                        local ext = filename:match('%.([^%.]+)$')
-                        local map = { lua = 'lua', py = 'python' }
-                        return map[ext]
-                    end,
+                    get_language_from_filename = function(_filename) return 'lua' end,
+                    read_file_lines = function(_filepath) return {} end,
                 }
                 package.loaded['delta.utils_treesitter'] = {
                     get_treesitter_highlight_captures = function(_content, _lang) return {} end,
@@ -93,10 +91,6 @@ local T = new_set({
                 package.loaded['delta.utils_highlighting'] = {
                     get_highlights_multiple_files = function(_files, _opts) return {} end,
                 }
-
-                vim.fn.systemlist = function(_cmd) return {} end
-                -- Note: vim.v.shell_error is read-only; stubbing systemlist above
-                -- prevents the real shell command from running, keeping shell_error = 0
             ]])
             child.lua([[M = require('delta.diff')]])
             child.lua([[_G.fixture = {}]])
@@ -117,9 +111,16 @@ T['git_diff()'] = new_set({
                 vim.system = function(_cmd, _opts)
                     return { wait = function() return { code = 0, stdout = '', stderr = '' } end }
                 end
-                -- Stub systemlist to return a fake git root; this also prevents the real
-                -- shell command from running, keeping vim.v.shell_error at 0 (its default)
-                vim.fn.systemlist = function(_cmd) return { '/fake/git/root' } end
+                M.get_diff_data_git = function(_diffstring) return { _G.fixture.fake_diff_data } end
+                M.create_formatted_buffer = function(_data)
+                    _G.fixture.create_formatted_buffer_called = true
+                    _G.fixture.create_formatted_buffer_data = _data
+                    -- return a real scratch buffer so vim.b[buf_id] assignments in git_diff succeed
+                    local bufnr = vim.api.nvim_create_buf(false, true)
+                    _G.fixture.fake_bufnr = bufnr
+                    return bufnr
+                end
+                _G.fixture.fake_diff_data = { new_path = 'foo.lua', hunks = {} }
             ]])
         end,
     },
@@ -130,121 +131,172 @@ T['git_diff()']['returns nil when git produces no output'] = function()
     eq(is_nil, true)
 end
 
-T['git_diff()']['returns valid bufnr when diff has changes'] = function()
+T['git_diff()']['returns the bufnr from create_formatted_buffer when diff has changes'] = function()
     child.lua([[
-        _G.fixture.diff_output = ...
         vim.system = function(_cmd, _opts)
-            return { wait = function() return { code = 0, stdout = _G.fixture.diff_output, stderr = '' } end }
+            return { wait = function() return { code = 0, stdout = 'some diff output', stderr = '' } end }
         end
-    ]], { git_diff_fixture })
-    local valid = child.lua_get([[(function()
-        local bufnr = M.git_diff('HEAD', nil, {})
-        return bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr)
-    end)()]])
-    eq(valid, true)
+        _G.fixture.returned_bufnr = M.git_diff('HEAD', nil, {})
+    ]])
+    local matches = child.lua_get([[_G.fixture.returned_bufnr == _G.fixture.fake_bufnr]])
+    eq(matches, true)
 end
 
-T['git_diff()']['delta_diff_data_set contains the parsed file path'] = function()
+T['git_diff()']['passes diff output to get_diff_data_git'] = function()
     child.lua([[
-        _G.fixture.diff_output = ...
+        _G.fixture.get_diff_data_git_input = nil
+        local diff_output = ...
         vim.system = function(_cmd, _opts)
-            return { wait = function() return { code = 0, stdout = _G.fixture.diff_output, stderr = '' } end }
+            return { wait = function() return { code = 0, stdout = diff_output, stderr = '' } end }
+        end
+        M.get_diff_data_git = function(diffstring)
+            _G.fixture.get_diff_data_git_input = diffstring
+            return { _G.fixture.fake_diff_data }
         end
     ]], { git_diff_fixture })
-    local path = child.lua_get([[(function()
-        local bufnr = M.git_diff('HEAD', nil, {})
-        return vim.b[bufnr].delta_diff_data_set[1].new_path
+    child.lua([[M.git_diff('HEAD', nil, {})]])
+    local input = child.lua_get([[_G.fixture.get_diff_data_git_input]])
+    eq(input, git_diff_fixture)
+end
+
+T['git_diff()']['sets git_root buffer variable on the returned buffer'] = function()
+    child.lua([[
+        vim.system = function(_cmd, _opts)
+            return { wait = function() return { code = 0, stdout = 'some diff output', stderr = '' } end }
+        end
+        M.git_diff('HEAD', nil, {})
+    ]])
+    local git_root_set = child.lua_get([[vim.b[_G.fixture.fake_bufnr].git_root ~= nil]])
+    eq(git_root_set, true)
+end
+
+T['git_diff()']['throws an error when git diff returns a failing exit code'] = function()
+    child.lua([[
+        vim.system = function(_cmd, _opts)
+            return { wait = function() return { code = 128, stdout = '', stderr = 'fatal: not a repo' } end }
+        end
+    ]])
+    local ok = child.lua_get([[(function()
+        local ok, _ = pcall(M.git_diff, 'HEAD', nil, {})
+        return ok
     end)()]])
-    eq(path, 'foo.lua')
+    eq(ok, false)
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- text_diff() - example based tests
 
-T['text_diff()'] = new_set()
+T['text_diff()'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua([[
+                M.get_diff_data = function(_diffstring, _language)
+                    _G.fixture.get_diff_data_called = true
+                    return _G.fixture.fake_diff_data
+                end
+                M.create_formatted_buffer = function(_data)
+                    _G.fixture.create_formatted_buffer_called = true
+                    return _G.fixture.fake_bufnr
+                end
+                _G.fixture.fake_bufnr = 42
+                _G.fixture.fake_diff_data = { language = 'lua', hunks = {} }
+            ]])
+        end,
+    },
+})
 
-T['text_diff()']['returns valid bufnr for two differing strings'] = function()
-    local valid = child.lua_get([[(function()
-        local bufnr = M.text_diff('local x = 1\nlocal y = 2', 'local x = 1\nlocal y = 10', 'lua', {})
-        return bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr)
-    end)()]])
-    eq(valid, true)
+T['text_diff()']['returns the bufnr from create_formatted_buffer'] = function()
+    local bufnr = child.lua_get([[M.text_diff('local x = 1', 'local x = 2', 'lua', {})]])
+    eq(bufnr, 42)
 end
 
-T['text_diff()']['buffer is not modifiable'] = function()
-    local modifiable = child.lua_get([[(function()
-        local bufnr = M.text_diff('local x = 1\nlocal y = 2', 'local x = 1\nlocal y = 10', 'lua', {})
-        return vim.api.nvim_get_option_value('modifiable', { buf = bufnr })
-    end)()]])
-    eq(modifiable, false)
+T['text_diff()']['passes diff output to get_diff_data'] = function()
+    child.lua([[
+        _G.fixture.get_diff_data_input = nil
+        M.get_diff_data = function(diffstring, _language)
+            _G.fixture.get_diff_data_input = diffstring
+            return _G.fixture.fake_diff_data
+        end
+    ]])
+    child.lua([[M.text_diff('local x = 1\n', 'local x = 2\n', 'lua', {})]])
+    local input = child.lua_get([[_G.fixture.get_diff_data_input]])
+    eq(input ~= nil, true)
 end
 
 T['text_diff()']['falls back to vim.diff when vim.text is unavailable'] = function()
     local used_vim_diff = child.lua_get([[(function()
         local called = false
         vim.text = nil
-        vim.diff = function(s1, s2, opts)
+        vim.diff = function(_s1, _s2, _opts)
             called = true
-            return '@@ -1,2 +1,2 @@\n local x = 1\n-local y = 2\n+local y = 10\n'
+            return '@@ -1,1 +1,1 @@\n-local x = 1\n+local x = 2\n'
         end
-        M.text_diff('local x = 1\nlocal y = 2', 'local x = 1\nlocal y = 10', 'lua', {})
+        M.text_diff('local x = 1', 'local x = 2', 'lua', {})
         return called
     end)()]])
     eq(used_vim_diff, true)
 end
 
-T['text_diff()']['delta_diff_data_set contains a hunk for the changed line'] = function()
-    local hunk_count = child.lua_get([[(function()
-        local bufnr = M.text_diff('local x = 1\nlocal y = 2', 'local x = 1\nlocal y = 10', 'lua', {})
-        return #vim.b[bufnr].delta_diff_data_set[1].hunks
-    end)()]])
-    eq(hunk_count, 1)
-end
-
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- patch_diff() - example based tests
 
-T['patch_diff()'] = new_set()
+T['patch_diff()'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua([[
+                M.get_diff_data = function(_diffstring, _language)
+                    return _G.fixture.fake_diff_data
+                end
+                M.get_diff_data_git = function(_diffstring)
+                    return { _G.fixture.fake_diff_data }
+                end
+                M.create_formatted_buffer = function(_data)
+                    _G.fixture.create_formatted_buffer_data = _data
+                    return _G.fixture.fake_bufnr
+                end
+                _G.fixture.fake_bufnr = 42
+                _G.fixture.fake_diff_data = { new_path = 'foo.lua', hunks = {} }
+            ]])
+        end,
+    },
+})
 
 T['patch_diff()']['returns nil when diffstring is empty'] = function()
     local is_nil = child.lua_get([[M.patch_diff('', false, 'lua', {}) == nil]])
     eq(is_nil, true)
 end
 
-T['patch_diff()']['plain unified diff: returns valid bufnr'] = function()
+T['patch_diff()']['plain unified diff: returns bufnr from create_formatted_buffer'] = function()
     child.lua([[_G.fixture.diff_input = ...]], { patch_fixture })
-    local valid = child.lua_get([[(function()
-        local bufnr = M.patch_diff(_G.fixture.diff_input, false, 'lua', {})
-        return bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr)
-    end)()]])
-    eq(valid, true)
+    local bufnr = child.lua_get([[M.patch_diff(_G.fixture.diff_input, false, 'lua', {})]])
+    eq(bufnr, 42)
 end
 
-T['patch_diff()']['plain unified diff: buffer has delta_diff_data_set'] = function()
+T['patch_diff()']['plain unified diff: wraps result of get_diff_data in a table for create_formatted_buffer'] = function()
     child.lua([[_G.fixture.diff_input = ...]], { patch_fixture })
-    local has_data = child.lua_get([[(function()
-        local bufnr = M.patch_diff(_G.fixture.diff_input, false, 'lua', {})
-        return vim.b[bufnr].delta_diff_data_set ~= nil
-    end)()]])
-    eq(has_data, true)
+    child.lua([[M.patch_diff(_G.fixture.diff_input, false, 'lua', {})]])
+    local data_is_table = child.lua_get([[type(_G.fixture.create_formatted_buffer_data) == 'table']])
+    eq(data_is_table, true)
 end
 
-T['patch_diff()']['git diff format: returns valid bufnr'] = function()
+T['patch_diff()']['git diff format: returns bufnr from create_formatted_buffer'] = function()
     child.lua([[_G.fixture.diff_input = ...]], { git_diff_fixture })
-    local valid = child.lua_get([[(function()
-        local bufnr = M.patch_diff(_G.fixture.diff_input, true, nil, {})
-        return bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr)
-    end)()]])
-    eq(valid, true)
+    local bufnr = child.lua_get([[M.patch_diff(_G.fixture.diff_input, true, nil, {})]])
+    eq(bufnr, 42)
 end
 
-T['patch_diff()']['git diff format: delta_diff_data_set has correct file path'] = function()
-    child.lua([[_G.fixture.diff_input = ...]], { git_diff_fixture })
-    local path = child.lua_get([[(function()
-        local bufnr = M.patch_diff(_G.fixture.diff_input, true, nil, {})
-        return vim.b[bufnr].delta_diff_data_set[1].new_path
-    end)()]])
-    eq(path, 'foo.lua')
+T['patch_diff()']['git diff format: passes diffstring to get_diff_data_git'] = function()
+    child.lua([[
+        _G.fixture.get_diff_data_git_input = nil
+        M.get_diff_data_git = function(diffstring)
+            _G.fixture.get_diff_data_git_input = diffstring
+            return { _G.fixture.fake_diff_data }
+        end
+        _G.fixture.diff_input = ...
+    ]], { git_diff_fixture })
+    child.lua([[M.patch_diff(_G.fixture.diff_input, true, nil, {})]])
+    local input = child.lua_get([[_G.fixture.get_diff_data_git_input]])
+    eq(input, git_diff_fixture)
 end
 
 return T

--- a/tests/delta/test_integrations.lua
+++ b/tests/delta/test_integrations.lua
@@ -102,6 +102,28 @@ local git_diff_fixture = table.concat({
     " local w = 4",
 }, "\n")
 
+-- A temp git repo with a working-tree change, but cwd set to /tmp (outside any git repo).
+-- The path to the file is stored in _G.fixture.filepath so tests can pass it explicitly.
+local setup_tmpdir_git_repo_cwd_outside = [[
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, 'p')
+    vim.fn.system('git -C ' .. tmpdir .. ' init')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.email "test@test.com"')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.name "Test"')
+    local f = io.open(tmpdir .. '/test.lua', 'w')
+    f:write('local x = 1\nlocal y = 2\n')
+    f:close()
+    vim.fn.system('git -C ' .. tmpdir .. ' add test.lua')
+    vim.fn.system('git -C ' .. tmpdir .. ' commit -m "initial"')
+    -- Make a working-tree change
+    local f2 = io.open(tmpdir .. '/test.lua', 'w')
+    f2:write('local x = 1\nlocal y = 99\n')
+    f2:close()
+    -- Deliberately set cwd to /tmp, which is outside any git repo
+    vim.cmd('cd /tmp')
+    _G.fixture = { tmpdir = tmpdir, filepath = tmpdir .. '/test.lua' }
+]]
+
 -- A temp git repo with a committed binary file and a working-tree modification to it.
 -- The binary content contains a null byte so git classifies it as binary.
 local setup_tmpdir_binary_file_repo = [[
@@ -202,21 +224,14 @@ T['git_diff integration']['happy path: full sequence sets statuscolumn on window
     eq(statuscolumn:find('delta.statuscolumn', 1, true) ~= nil, true)
 end
 
-T['git_diff integration']['failure path: not in a git repo returns nil and notifies'] = function()
+T['git_diff integration']['failure path: not in a git repo throws an error'] = function()
     -- cd to /tmp which is never inside a git repo
-    child.lua([[
-        _G.fixture.notify_called = false
-        _G.fixture.notify_msg = nil
-        vim.notify = function(msg, _level)
-            _G.fixture.notify_called = true
-            _G.fixture.notify_msg = msg
-        end
-        vim.cmd('cd /tmp')
-    ]])
-    local result = child.lua_get('M.git_diff("HEAD", nil, {})')
-    eq(result, vim.NIL)
-    local notify_called = child.lua_get('_G.fixture.notify_called')
-    eq(notify_called, true)
+    child.lua([[vim.cmd('cd /tmp')]])
+    local ok = child.lua_get([[(function()
+        local ok, _ = pcall(M.git_diff, 'HEAD', nil, {})
+        return ok
+    end)()]])
+    eq(ok, false)
 end
 
 T['git_diff integration']['failure path: no working-tree changes returns nil and notifies'] = function()
@@ -234,6 +249,24 @@ T['git_diff integration']['failure path: no working-tree changes returns nil and
     eq(result, vim.NIL)
     local notify_called = child.lua_get('_G.fixture.notify_called')
     eq(notify_called, true)
+end
+
+T['git_diff integration']['happy path: cwd outside git repo but path inside returns valid buffer'] = function()
+    -- Override fixture: cwd is /tmp, path points into the real git repo
+    child.lua(setup_tmpdir_git_repo_cwd_outside)
+    local bufnr = child.lua_get([[(function()
+        local filepath = _G.fixture.filepath
+        local ok, val = pcall(M.git_diff, 'HEAD', filepath, {})
+        if not ok then return nil end
+        return val
+    end)()]])
+    eq(type(bufnr), 'number')
+    local is_valid = child.lua_get(string.format('vim.api.nvim_buf_is_valid(%d)', bufnr))
+    eq(is_valid, true)
+    local has_diff_data = child.lua_get(string.format('vim.b[%d].delta_diff_data_set ~= nil', bufnr))
+    eq(has_diff_data, true)
+    local git_root_set = child.lua_get(string.format('vim.b[%d].git_root ~= nil', bufnr))
+    eq(git_root_set, true)
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────

--- a/tests/delta/test_utils.lua
+++ b/tests/delta/test_utils.lua
@@ -1,0 +1,251 @@
+local new_set = MiniTest.new_set
+local eq = MiniTest.expect.equality
+
+local child = MiniTest.new_child_neovim()
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- utility
+
+-- usage: add the following to a pre case
+-- child.lua(test_logging)
+local test_logging = [[
+    _G.test_logs = {}
+    _G.captured_prints = {}
+    local original_print = print
+    print = function(...)
+      local args = {...}
+      local msg = table.concat(vim.tbl_map(tostring, args), ' ')
+      table.insert(_G.captured_prints, msg)
+      original_print(...)  -- Still call original for child's output
+    end
+]]
+
+-- usage: add the following to the new_set
+-- post_case = print_test_logging
+local print_test_logging = function()
+    local captured_prints = child.lua_get('_G.captured_prints')
+    if captured_prints and #captured_prints > 0 then
+        print('\n=== Child Neovim Print Statements ===')
+        for i, msg in ipairs(captured_prints) do
+            print(string.format('[%d] %s', i, msg))
+        end
+        print('=== End Print Statements ===\n')
+    end
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- setup
+
+local T = new_set({
+    hooks = {
+        pre_case = function()
+            child.restart({ '-u', 'scripts/minimal_init.lua' })
+            child.lua([[M = require('delta.utils')]])
+            child.lua([[_G.fixture = {}]])
+            child.lua(test_logging)
+        end,
+        post_case = print_test_logging,
+        post_once = child.stop,
+    },
+})
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- get_git_root() - example based tests
+
+T['get_git_root()'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua([[
+                vim.fn.isdirectory = function(_) return 0 end
+                vim.fn.fnamemodify = function(path, _) return path end
+                vim.system = function(_cmd, _opts)
+                    return { wait = function()
+                        return { code = 0, stdout = '/fake/git/root\n', stderr = '' }
+                    end }
+                end
+            ]])
+        end,
+    },
+})
+
+T['get_git_root()']['returns trimmed stdout when git succeeds (code 0)'] = function()
+    local result = child.lua_get([[(function()
+        local ok, val = pcall(M.get_git_root, '/some/file.lua')
+        if not ok then return nil end
+        return val
+    end)()]])
+
+    eq(result, '/fake/git/root')
+end
+
+T['get_git_root()']['uses fnamemodify to get parent dir when path is not a directory'] = function()
+    child.lua([[
+        _G.fixture.fnamemodify_args = nil
+        vim.fn.isdirectory = function(_) return 0 end
+        vim.fn.fnamemodify = function(path, mod)
+            _G.fixture.fnamemodify_args = { path = path, mod = mod }
+            return '/parent/dir'
+        end
+    ]])
+
+    child.lua([[ pcall(M.get_git_root, '/some/file.lua') ]])
+
+    local args = child.lua_get([[_G.fixture.fnamemodify_args]])
+    eq(args.path, '/some/file.lua')
+    eq(args.mod, ':h')
+end
+
+T['get_git_root()']['uses path directly when it is a directory'] = function()
+    child.lua([[
+        _G.fixture.system_dir = nil
+        vim.fn.isdirectory = function(_) return 1 end
+        vim.system = function(cmd, _opts)
+            _G.fixture.system_dir = cmd[3]  -- git -C <dir> rev-parse ...
+            return { wait = function()
+                return { code = 0, stdout = '/fake/git/root\n', stderr = '' }
+            end }
+        end
+    ]])
+
+    child.lua([[ pcall(M.get_git_root, '/some/dir') ]])
+
+    local dir = child.lua_get([[_G.fixture.system_dir]])
+    eq(dir, '/some/dir')
+end
+
+T['get_git_root()']['asserts and throws when git returns a non-zero/non-one exit code'] = function()
+    child.lua([[
+        vim.system = function(_cmd, _opts)
+            return { wait = function()
+                return { code = 128, stdout = '', stderr = 'not a git repo' }
+            end }
+        end
+    ]])
+
+    local ok = child.lua_get([[(function()
+        local ok, _ = pcall(M.get_git_root, '/some/file.lua')
+        return ok
+    end)()]])
+
+    eq(ok, false)
+end
+
+T['get_git_root()']['does not throw when git returns code 1'] = function()
+    child.lua([[
+        vim.system = function(_cmd, _opts)
+            return { wait = function()
+                return { code = 1, stdout = '', stderr = '' }
+            end }
+        end
+    ]])
+
+    local ok = child.lua_get([[(function()
+        local ok, _ = pcall(M.get_git_root, '/some/file.lua')
+        return ok
+    end)()]])
+
+    eq(ok, true)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- build_git_diff_cmd_with_flags() - example based tests
+
+T['build_git_diff_cmd_with_flags()'] = new_set()
+
+T['build_git_diff_cmd_with_flags()']['returns base command with --full-index always present'] = function()
+    local result = child.lua_get([[(function()
+        return M.build_git_diff_cmd_with_flags({}, 'HEAD', '/repo')
+    end)()]])
+
+    eq(result[1], 'git')
+    eq(result[2], '-C')
+    eq(result[3], '/repo')
+    eq(result[4], 'diff')
+    eq(result[5], '--full-index')
+end
+
+T['build_git_diff_cmd_with_flags()']['inserts -U<n> context flag when context is set'] = function()
+    eq(child.lua_get([[
+        (function()
+            local cmd = M.build_git_diff_cmd_with_flags({ context = 5 }, 'HEAD', '/repo')
+            for _, v in ipairs(cmd) do
+                if v == '-U5' then return true end
+            end
+            return false
+        end)()
+    ]]), true)
+end
+
+T['build_git_diff_cmd_with_flags()']['omits context flag when context is nil'] = function()
+    local result = child.lua_get([[
+        (function()
+            local cmd = M.build_git_diff_cmd_with_flags({}, 'HEAD', '/repo')
+            for _, v in ipairs(cmd) do
+                if v:sub(1, 2) == '-U' then return false end
+            end
+            return true
+        end)()
+    ]])
+
+    eq(result, true)
+end
+
+T['build_git_diff_cmd_with_flags()']['includes ref when new_file is not true and ref is provided'] = function()
+    local result = child.lua_get([[(function()
+        return M.build_git_diff_cmd_with_flags({}, 'HEAD~1', '/repo')
+    end)()]])
+
+    local found = false
+    for _, v in ipairs(result) do
+        if v == 'HEAD~1' then found = true end
+    end
+    eq(found, true)
+end
+
+T['build_git_diff_cmd_with_flags()']['excludes ref and adds --no-index when new_file is true'] = function()
+    local result = child.lua_get([[(function()
+        return M.build_git_diff_cmd_with_flags({ new_file = true }, 'HEAD', '/repo')
+    end)()]])
+
+    local has_ref = false
+    local has_no_index = false
+    for _, v in ipairs(result) do
+        if v == 'HEAD' then has_ref = true end
+        if v == '--no-index' then has_no_index = true end
+    end
+    eq(has_ref, false)
+    eq(has_no_index, true)
+end
+
+T['build_git_diff_cmd_with_flags()']['appends -- and path when path is provided'] = function()
+    local result = child.lua_get([[(function()
+        return M.build_git_diff_cmd_with_flags({}, 'HEAD', '/repo', '/repo/foo.lua')
+    end)()]])
+
+    local n = #result
+    eq(result[n], '/repo/foo.lua')
+    eq(result[n - 1], '--')
+end
+
+T['build_git_diff_cmd_with_flags()']['inserts /dev/null before path when new_file is true'] = function()
+    local result = child.lua_get([[(function()
+        return M.build_git_diff_cmd_with_flags({ new_file = true }, nil, '/repo', '/repo/new.lua')
+    end)()]])
+
+    local n = #result
+    eq(result[n], '/repo/new.lua')
+    eq(result[n - 1], '/dev/null')
+    eq(result[n - 2], '--')
+end
+
+T['build_git_diff_cmd_with_flags()']['omits -- separator and path when path is nil'] = function()
+    local result = child.lua_get([[(function()
+        return M.build_git_diff_cmd_with_flags({}, 'HEAD', '/repo', nil)
+    end)()]])
+
+    for _, v in ipairs(result) do
+        eq(v == '--', false)
+    end
+end
+
+return T

--- a/tests/delta/test_utils.lua
+++ b/tests/delta/test_utils.lua
@@ -113,7 +113,7 @@ T['get_git_root()']['uses path directly when it is a directory'] = function()
     eq(dir, '/some/dir')
 end
 
-T['get_git_root()']['asserts and throws when git returns a non-zero/non-one exit code'] = function()
+T['get_git_root()']['asserts and throws when git returns a non-zero exit code'] = function()
     child.lua([[
         vim.system = function(_cmd, _opts)
             return { wait = function()
@@ -130,7 +130,7 @@ T['get_git_root()']['asserts and throws when git returns a non-zero/non-one exit
     eq(ok, false)
 end
 
-T['get_git_root()']['does not throw when git returns code 1'] = function()
+T['get_git_root()']['asserts and throws when git returns code 1'] = function()
     child.lua([[
         vim.system = function(_cmd, _opts)
             return { wait = function()
@@ -144,7 +144,7 @@ T['get_git_root()']['does not throw when git returns code 1'] = function()
         return ok
     end)()]])
 
-    eq(ok, true)
+    eq(ok, false)
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
the git_diff function should be agnostic of the neovim cwd, and that change was implemented here. This change was required to implement the feature request in https://github.com/kokusenz/deltaview.nvim/issues/26. This change is not required for the :DeltaView part of that feature request, but is required for :Delta. This change does not depend on the related change made in DeltaView (addressing the same feature request). 

This change also changes the behavior of calling git_diff on a path that is not in a git repository. Instead of notifying, this now errors. Consumers should update their usage to use pcall rather than relying on the notification. This change is intentional, and allows consumers to control how they surface this error. Furthermore, this error being triggered is a consumer/code issue, not a user issue, so notify didn't feel like the right choice for this.