### PR TITLE
Support foldcolumn=auto by using built-in text offset from vim.fn.getwininfo()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@ I try to attach a commit to each log, but in the initial pr, I may use the pr in
 
 ## Latest
 
-### [0.1.3] - 2026-05-7 to ongoing
+### [0.1.4] - 2026-06-02 to ongoing
+
+#### Fixes
+- `get_window_width` now uses `vim.fn.getwininfo()` to derive window width and text offset, replacing individual `nvim_get_option_value` calls per gutter option.
+
+## History
+
+### [0.1.3] - 2026-05-27 to 2026-06-02
 
 - initial commit - https://github.com/kokusenz/delta.lua/pull/8
 
 #### Fixes
 - `--no-ext-diff` is passed as a flag into all git diff invocations, to avoid crashing with diff.external configuration (such as difftastic).
-
-## History
 
 ### [0.1.2] - 2026-04-27 to 2026-05-27
 

--- a/lua/delta/utils.lua
+++ b/lua/delta/utils.lua
@@ -139,21 +139,9 @@ M.get_extension_from_language = function(language)
 end
 
 M.get_window_width = function(winid)
-    local win_width = vim.api.nvim_win_get_width(winid)
-    local numberwidth = vim.api.nvim_get_option_value('numberwidth', { win = winid })
-    local signcolumn = vim.api.nvim_get_option_value('signcolumn', { win = winid })
-    local foldcolumn = vim.api.nvim_get_option_value('foldcolumn', { win = winid })
-
-    local gutter_width = 0
-    if vim.api.nvim_get_option_value('number', { win = winid }) or vim.api.nvim_get_option_value('relativenumber', { win = winid }) then
-        gutter_width = gutter_width + numberwidth
-    end
-    if signcolumn == 'yes' or signcolumn == 'auto' then
-        gutter_width = gutter_width + 2 -- sign column is typically 2 chars wide
-    end
-    gutter_width = gutter_width + tonumber(foldcolumn)
-
-    return win_width - gutter_width
+    local win = (winid == 0) and vim.api.nvim_get_current_win() or winid
+    local info = vim.fn.getwininfo(win)[1]
+    return info.width - info.textoff
 end
 
 --- Builds the git diff cmd with CLI flags string from effective opts

--- a/tests/delta/test_utils.lua
+++ b/tests/delta/test_utils.lua
@@ -249,4 +249,113 @@ T['build_git_diff_cmd_with_flags()']['omits -- separator and path when path is n
     end
 end
 
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- get_window_width() - example based tests
+
+T['get_window_width()'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua([[
+                local bufnr = vim.api.nvim_create_buf(true, true)
+                vim.api.nvim_set_current_buf(bufnr)
+                _G.fixture.bufnr = bufnr
+                _G.fixture.winnr = vim.api.nvim_get_current_win()
+            ]])
+        end,
+    },
+})
+
+T['get_window_width()']['returns a number when winid is 0'] = function()
+    local result = child.lua_get('M.get_window_width(0)')
+    eq(type(result), 'number')
+end
+
+T['get_window_width()']['winid 0 gives the same result as the explicit current win id'] = function()
+    local result = child.lua_get([[(function()
+        local with_zero = M.get_window_width(0)
+        local with_id   = M.get_window_width(vim.api.nvim_get_current_win())
+        return with_zero == with_id
+    end)()]])
+    eq(result, true)
+end
+
+T['get_window_width()']['result equals getwininfo width minus textoff'] = function()
+    local result = child.lua_get([[(function()
+        local winnr      = vim.api.nvim_get_current_win()
+        local calculated = M.get_window_width(winnr)
+        local info       = vim.fn.getwininfo(winnr)[1]
+        return calculated == (info.width - info.textoff)
+    end)()]])
+    eq(result, true)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- get_window_width() - property based tests
+
+local GetWindowWidth = {}
+
+GetWindowWidth.get_inputs = function(_case)
+    local inputs = {}
+    local foldcolumn_vals     = { '1', 'auto', 'auto:3' }
+    local signcolumn_vals     = { 'no', 'yes', 'auto' }
+    local number_vals         = { false, true }
+    local relativenumber_vals = { false, true }
+
+    for _, fc  in ipairs(foldcolumn_vals) do
+        for _, sc  in ipairs(signcolumn_vals) do
+            for _, nu  in ipairs(number_vals) do
+                for _, rnu in ipairs(relativenumber_vals) do
+                    table.insert(inputs, {
+                        foldcolumn     = fc,
+                        signcolumn     = sc,
+                        number         = nu,
+                        relativenumber = rnu,
+                    })
+                end
+            end
+        end
+    end
+    return inputs
+end
+
+GetWindowWidth.get_window_width__property_cases = {
+    { name = 'all option permutations', buf_contents = {}, get_inputs = GetWindowWidth.get_inputs },
+}
+
+GetWindowWidth.properties = {}
+
+GetWindowWidth.properties.result_equals_width_minus_textoff = [[(function()
+    local inputs = _G.fixture.inputs
+    local winnr  = _G.fixture.winnr
+    for _, input in ipairs(inputs) do
+        vim.api.nvim_set_option_value('foldcolumn',     input.foldcolumn,     { win = winnr })
+        vim.api.nvim_set_option_value('signcolumn',     input.signcolumn,     { win = winnr })
+        vim.api.nvim_set_option_value('number',         input.number,         { win = winnr })
+        vim.api.nvim_set_option_value('relativenumber', input.relativenumber, { win = winnr })
+        local result = M.get_window_width(winnr)
+        local info   = vim.fn.getwininfo(winnr)[1]
+        if result ~= (info.width - info.textoff) then return false end
+    end
+    return true
+end)()]]
+
+T['get_window_width() properties'] = new_set()
+for prop_name, prop in pairs(GetWindowWidth.properties) do
+    for _, case in ipairs(GetWindowWidth.get_window_width__property_cases) do
+        T['get_window_width() properties'][prop_name .. ': ' .. case.name] = function()
+            child.lua([[
+                local buf_contents = ...
+                local bufnr = vim.api.nvim_create_buf(true, true)
+                vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, buf_contents)
+                vim.api.nvim_set_current_buf(bufnr)
+                _G.fixture.bufnr = bufnr
+                _G.fixture.winnr = vim.api.nvim_get_current_win()
+            ]], { case.buf_contents })
+            child.lua([[_G.fixture.inputs = ...]], { case.get_inputs(case) })
+            local result = child.lua_get(prop)
+            eq(result, true)
+        end
+    end
+end
+
 return T


### PR DESCRIPTION
## Context

See https://github.com/kokusenz/deltaview.nvim/issues/46 for full context. In short, we can lean on neovim to calculate the width of gutter elements (`foldcolumn`, `signcolumn`, line numbers) rather the current duplicate, lower fidelity implementation.

## Changes

Uses `vim.fn.getwininfo()` to determine window dimensions when calculating available window width, including the pre-calculated `textoff` which is the sum of all gutter elements.

## Testing

PBTs have been added to cover permutations of `foldcolumn`, `signcolumn`, `number`, and `relativenumber`. This results in 36 permutations, which feels a little high but does provide comprehensive coverage that we always get a numeric value back from the function.

The tests may be a little rough around the edges - while I'm familiar with PBTs in other languages I'm not sure these ones are shining examples of idiomatic Lua 😆 