### PR TITLE
Fix get_window_width crash with auto:N foldcolumn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ I try to attach a commit to each log, but in the initial pr, I may use the pr in
 
 #### Fixes
 - `--no-ext-diff` is passed as a flag into all git diff invocations, to avoid crashing with diff.external configuration (such as difftastic).
+- `get_window_width` no longer crashes when `'foldcolumn'` is set to the `auto`/`auto:N` form (e.g. `auto:9`). It now derives the gutter width from `getwininfo().textoff`, which reflects the actually-rendered gutter and tracks the fold level. - PR_LINK_PLACEHOLDER
 
 ## History
 

--- a/lua/delta/utils.lua
+++ b/lua/delta/utils.lua
@@ -139,19 +139,17 @@ M.get_extension_from_language = function(language)
 end
 
 M.get_window_width = function(winid)
+    -- vim.fn.getwininfo() doesn't treat 0 as the current window the way the
+    -- nvim_* API does, so resolve it explicitly.
+    if winid == 0 then winid = vim.api.nvim_get_current_win() end
     local win_width = vim.api.nvim_win_get_width(winid)
-    local numberwidth = vim.api.nvim_get_option_value('numberwidth', { win = winid })
-    local signcolumn = vim.api.nvim_get_option_value('signcolumn', { win = winid })
-    local foldcolumn = vim.api.nvim_get_option_value('foldcolumn', { win = winid })
 
-    local gutter_width = 0
-    if vim.api.nvim_get_option_value('number', { win = winid }) or vim.api.nvim_get_option_value('relativenumber', { win = winid }) then
-        gutter_width = gutter_width + numberwidth
-    end
-    if signcolumn == 'yes' or signcolumn == 'auto' then
-        gutter_width = gutter_width + 2 -- sign column is typically 2 chars wide
-    end
-    gutter_width = gutter_width + tonumber(foldcolumn)
+    -- 'textoff' is the count of columns actually occupied by the line-number,
+    -- 'signcolumn' and 'foldcolumn' gutters as currently rendered. Using it
+    -- avoids reinventing that math, and correctly handles the 'auto'/'auto:N'
+    -- forms of 'foldcolumn' (whose width tracks the folds actually present)
+    -- and 'signcolumn', where tonumber()/== 'auto' checks would break or undercount.
+    local gutter_width = vim.fn.getwininfo(winid)[1].textoff
 
     return win_width - gutter_width
 end

--- a/tests/delta/test_utils.lua
+++ b/tests/delta/test_utils.lua
@@ -249,4 +249,54 @@ T['build_git_diff_cmd_with_flags()']['omits -- separator and path when path is n
     end
 end
 
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- get_window_width()
+
+T['get_window_width()'] = new_set()
+
+-- regression: 'foldcolumn' accepts the 'auto'/'auto:N' forms, not just a plain
+-- number. tonumber('auto:9') is nil, which previously crashed get_window_width
+-- with "attempt to perform arithmetic on a nil value".
+T['get_window_width()']['does not error with auto:N foldcolumn'] = function()
+    local result = child.lua_get([[(function()
+        vim.o.foldcolumn = 'auto:9'
+        vim.o.number = true
+        vim.o.signcolumn = 'yes'
+        local ok, val = pcall(M.get_window_width, 0)
+        return { ok = ok, val = val }
+    end)()]])
+
+    eq(result.ok, true)
+    eq(type(result.val), 'number')
+end
+
+-- width is the window's full width minus the rendered gutter ('textoff').
+T['get_window_width()']['subtracts the rendered gutter width'] = function()
+    local result = child.lua_get([[(function()
+        vim.o.foldcolumn = 'auto:9'
+        vim.o.number = true
+        vim.o.signcolumn = 'yes'
+        local win = vim.api.nvim_get_current_win()
+        local full = vim.api.nvim_win_get_width(win)
+        local textoff = vim.fn.getwininfo(win)[1].textoff
+        return { expected = full - textoff, actual = M.get_window_width(0) }
+    end)()]])
+
+    eq(result.actual, result.expected)
+end
+
+-- with no gutter, the full window width is returned.
+T['get_window_width()']['returns full width when no gutter is shown'] = function()
+    local result = child.lua_get([[(function()
+        vim.o.foldcolumn = '0'
+        vim.o.number = false
+        vim.o.relativenumber = false
+        vim.o.signcolumn = 'no'
+        local win = vim.api.nvim_get_current_win()
+        return { full = vim.api.nvim_win_get_width(win), actual = M.get_window_width(0) }
+    end)()]])
+
+    eq(result.actual, result.full)
+end
+
 return T


### PR DESCRIPTION
get_window_width assumed 'foldcolumn' was always numeric and did arithmetic on tonumber(foldcolumn). For the 'auto'/'auto:N' forms (e.g. 'auto:9') tonumber returns nil, raising "attempt to perform arithmetic on a nil value" and breaking any caller (e.g. opening a DeltaView).

Derive the gutter width from getwininfo().textoff instead, which is the gutter width as actually rendered. This handles 'foldcolumn' 'auto'/'auto:N' (tracking the fold level currently shown), and also fixes two latent undercounts in the old math: 'numberwidth' added under the 'auto' number forms, and 'signcolumn=auto:N'.

getwininfo() does not treat winid 0 as the current window the way the nvim_* API does, so resolve it explicitly first.

Add regression tests covering the auto:N case, the textoff subtraction, and the no-gutter case.